### PR TITLE
update instructions and jamsocket config to work with new dev cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,32 +1,30 @@
 # Prequisites
 1. Have Docker running
-2. Login to Jamsocket CLI `npx jamsocket@latest login`
+2. Have NodeJS >18 installed.
 
 ## Run Server
 1. Clone project
 2. `cd server`
-3. Create a service with `npx jamsocket service create python-fastapi-helloworld`
-4. Run `npx jamsocket dev` which builds a new docker image using `Dockerfile` and `jamsocket.config.js`
+3. Run `npx jamsocket dev` which builds a new docker image using `Dockerfile` and `jamsocket.config.js`
 
 ## Spawn the backend & get a response
-1. Run `curl -X POST http://localhost:8080/user/{ACCOUNT}/service/python-fastapi-helloworld/spawn`
+1. Run `curl -X POST http://localhost:8080/user/my-account/service/python-fastapi-helloworld/spawn`
 
 You should see a response like this:
 ```json
 {
-    "url":"https://i84or.jamsocket.run/",
-    "name":"i84or",
-    "ready_url":"https://api.jamsocket.com/ready/i84or/",
-    "status_url":"https://api.jamsocket.com/backend/i84or/status",
-    "spawned":true,
-    "status":"Loading"
+    "url": "http://localhost:9090/tYVHfS4PKgufdhwGCnn6LLfAaCo_iAHitbw4Bg8ETjA/",
+    "name": "ba-xt8nmtlgti18qx",
+    "status_url": "http://0.0.0.0:8080/pub/b/ba-xt8nmtlgti18qx/status",
+    "spawned": true,
+    "status": "Loading"
 }
 ```
 
 2. Use the url in the backend response and run `curl {BACKEND URL}`
 You should see a response like this:
 ```json
-{"res":"Hello World"}
+{ "res": "Hello World" }
 ```
 
-Or spawn and connect with a client library `@jamsocket/javascript`
+Or spawn and connect with Jamsocket's javascript client library, `@jamsocket/javascript`.

--- a/server/jamsocket.config.js
+++ b/server/jamsocket.config.js
@@ -1,5 +1,4 @@
 module.exports = {
   dockerfile: './Dockerfile',
-  service: 'python-fastapi-helloworld',
   watch: ['./server'],
 }


### PR DESCRIPTION
These are some changes to make sure this demo works with the newest version of the dev CLI. Let's wait until that version has been published before we land this, though. (`npx jamsocket@latest --version` should be >=0.8.0)